### PR TITLE
fakeUserId, realUserId, mobileOfferId fields visibility if they are empty strings

### DIFF
--- a/Changelogs/1.6.6
+++ b/Changelogs/1.6.6
@@ -1,0 +1,7 @@
+1.6.6 Release notes (2024-12-10)
+================================
+
+### Changes
+
+* fakeUserId and realUserId from MobileAppFakeUserIdReplacedEvent are being set as null if they are empty strings.
+* fakeUserId and mobileOfferId from PurchaseEvent are being set as null if they are empty strings.

--- a/RingPublishingTracking/src/main/java/com/ringpublishing/tracking/internal/factory/PaidEventsFactory.kt
+++ b/RingPublishingTracking/src/main/java/com/ringpublishing/tracking/internal/factory/PaidEventsFactory.kt
@@ -161,8 +161,8 @@ internal class PaidEventsFactory(private val gson: Gson) {
                     subscriptionPromoPrice = subscriptionPaymentData.subscriptionPromoPrice,
                     subscriptionPromoDuration = subscriptionPaymentData.subscriptionPromoDuration,
                     subscriptionPriceCurrency = subscriptionPaymentData.subscriptionPriceCurrency,
-                    fakeUserId = fakeUserId,
-                    mobileOfferId = offerData.mobileOfferId
+                    fakeUserId = fakeUserId?.takeIf { it.isNotBlank() },
+                    mobileOfferId = offerData.mobileOfferId?.takeIf { it.isNotBlank() }
                 )
             )?.let {
                 this[PaidEventParam.EVENT_DETAILS.text] = it
@@ -223,7 +223,12 @@ internal class PaidEventsFactory(private val gson: Gson) {
         val parameters = mutableMapOf<String, Any>().apply {
             this[PaidEventParam.EVENT_CATEGORY.text] = "mobile_app_fake_user_id_replaced"
             this[PaidEventParam.EVENT_ACTION.text] = "mobileAppFakeUserIdReplaced"
-            createUserIdEventDetailsDataJson(UserIdEventDetailsData(temporaryUserId, realUserId))?.let {
+            createUserIdEventDetailsDataJson(
+                UserIdEventDetailsData(
+                    fakeUserId = temporaryUserId.takeIf { it.isNotBlank() },
+                    realUserId = realUserId.takeIf { it.isNotBlank() }
+                )
+            )?.let {
                 this[PaidEventParam.EVENT_DETAILS.text] = it
             }
         }

--- a/RingPublishingTracking/src/test/java/com/ringpublishing/tracking/internal/factory/PaidEventsFactoryTest.kt
+++ b/RingPublishingTracking/src/test/java/com/ringpublishing/tracking/internal/factory/PaidEventsFactoryTest.kt
@@ -224,6 +224,44 @@ class PaidEventsFactoryTest
     }
 
     @Test
+    fun createPurchaseEventEmptyOfferIdAndFakeUserId_ThenProperParametersInEvent()
+    {
+        val eventsFactory = PaidEventsFactory(gson)
+        val sampleTpcc = "hard_xmass_promoInline"
+        val sampleTermId = "TMEVT00KVHV0"
+        val sampleFakeUserId = ""
+        val sampleTermConversionId = "TCCJTS9X87VB"
+        val sampleEventDetailsData =
+            "{\"subscription_base_price\":100.0,\"subscription_promo_price\":99.99,\"subscription_promo_duration\":\"1W\",\"subscription_price_currency\":\"usd\"}"
+        val event = eventsFactory.createPurchaseEvent(
+            contentMetadata = sampleContentMetadata,
+            offerData = sampleOfferData.copy(mobileOfferId = ""),
+            offerContextData = sampleOfferContextData.copy(closurePercentage = null),
+            subscriptionPaymentData = sampleSubscriptionPaymentData,
+            termId = sampleTermId,
+            termConversionId = sampleTermConversionId,
+            targetPromotionCampaignCode = sampleTpcc,
+            fakeUserId = sampleFakeUserId
+        )
+
+        Assert.assertTrue(event.parameters.isNotEmpty())
+        Assert.assertEquals(event.parameters[PaidEventParam.SUPPLIER_APP_ID.text], sampleOfferData.supplierData.supplierAppId)
+        Assert.assertEquals(event.parameters[PaidEventParam.PAYWALL_SUPPLIER.text], sampleOfferData.supplierData.paywallSupplier)
+        Assert.assertEquals(event.parameters[PaidEventParam.PAYWALL_TEMPLATE_ID.text], sampleOfferData.paywallTemplateId)
+        Assert.assertEquals(event.parameters[PaidEventParam.PAYWALL_VARIANT_ID.text], sampleOfferData.paywallVariantId)
+        Assert.assertEquals(event.parameters[PaidEventParam.SOURCE.text], sampleOfferContextData.source)
+        Assert.assertEquals(event.parameters[PaidEventParam.SOURCE_PUBLICATION_UUID.text], sampleContentMetadata.contentId)
+        Assert.assertEquals(event.parameters[PaidEventParam.SOURCE_DX.text], sampleContentMetadata.buildToDX())
+        Assert.assertEquals(event.parameters[PaidEventParam.CLOSURE_PERCENTAGE.text], null)
+        Assert.assertEquals(event.parameters[PaidEventParam.PAYMENT_METHOD.text], sampleSubscriptionPaymentData.paymentMethod.text)
+        Assert.assertEquals(event.parameters[PaidEventParam.TPCC.text], sampleTpcc)
+        Assert.assertEquals(event.parameters[PaidEventParam.TERM_ID.text], sampleTermId)
+        Assert.assertEquals(event.parameters[PaidEventParam.TERM_CONVERSION_ID.text], sampleTermConversionId)
+        Assert.assertEquals(event.parameters[PaidEventParam.EVENT_DETAILS.text], sampleEventDetailsData)
+        Assert.assertEquals(event.parameters[EventParam.MARKED_AS_PAID_DATA.text], mockRdlcnEncodingPaid())
+    }
+
+    @Test
     fun createShowMetricLimitEvent_ThenProperParametersInEvent()
     {
         val eventsFactory = PaidEventsFactory(gson)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 #Library version name
-sdk_version_name=1.6.5
+sdk_version_name=1.6.6
 #Library version code
 sdk_version_code=24


### PR DESCRIPTION
* fakeUserId and realUserId from MobileAppFakeUserIdReplacedEvent are being set as null if they are empty strings.
* fakeUserId and mobileOfferId from PurchaseEvent are being set as null if they are empty strings.
* Updated tests
* version = 1.6.6